### PR TITLE
Fix network config and add tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,10 @@ Set these in your repo under Settings > Secrets and variables > Actions:
 
 🌐 Access
 
-Once deployed, your Flask app will be accessible via:
-- http://<public-ip>:5000
-The public IP is exported by Pulumi after deployment.
+Once deployed, your Flask app will be accessible via the public IP exported by Pulumi:
+
+```bash
+pulumi stack output public_ip
+```
+
+Visit `http://<public-ip>:5000` using the output value.

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ Flask==2.3.2
 pulumi>=3.0.0,<4.0.0
 pulumi-aws>=6.0.2,<7.0.0
 pulumi-docker>=4.0.0,<5.0.0
+pytest

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,11 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+import app
+
+def test_index_route():
+    client = app.app.test_client()
+    resp = client.get('/')
+    assert resp.status_code == 200
+    assert b"Welcome to the Flask Bootstrap App" in resp.data


### PR DESCRIPTION
## Summary
- fix missing newline and add pytest dependency
- correct ECS service network config
- export service public IP and document how to retrieve it
- add basic Flask index route test

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*
- `python -m py_compile __main__.py`

------
https://chatgpt.com/codex/tasks/task_e_6842e4c733608321b97a7ad1cd805351