### PR TITLE
fix: handle missing ENI when exporting public IP

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,5 +66,6 @@ Once deployed, your Flask app will be accessible via the public IP exported by P
 ```bash
 pulumi stack output public_ip
 ```
+The value may be empty until the ECS task is running and a network interface has been created.
 
 Visit `http://<public-ip>:5000` using the output value.


### PR DESCRIPTION
## Summary
- prevent IndexError by checking network interfaces before accessing
- mention in docs that `pulumi stack output public_ip` may be empty until the ECS task starts

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement Flask==2.3.2)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6842ee9dd5108321bcb637d93385aa07