### PR TITLE
Fix tests for AZ output

### DIFF
--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -5,7 +5,9 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")
 import app
 
 def test_index_route():
-    client = app.app.test_client()
-    resp = client.get('/')
-    assert resp.status_code == 200
-    assert b"Welcome to the Flask Bootstrap App" in resp.data
+    os.environ["TASK_AZ"] = "test-az"
+    with app.app.test_client() as client:
+        resp = client.get('/')
+        assert resp.status_code == 200
+        assert b"Welcome to the Flask Bootstrap App" in resp.data
+        assert b"test-az" in resp.data


### PR DESCRIPTION
## Summary
- verify that TASK_AZ shows up in the page
- use Flask test client context manager for cleanup

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6842f5619a548321abec33606624a5d7