### PR TITLE
Fix README horizontal rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ The pipeline does:
 - Deploy using pulumi up
 - Trigger: On push to main branch.
 
------------------------------------------------------------------------
+---
 
 🔐 Secrets (GitHub Actions)
 


### PR DESCRIPTION
## Summary
- fix the horizontal rule in README so it renders correctly

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6842f5927ac4832186d25b9b211c25d8