### PR TITLE
fix: handle absent ENI when exporting public IP

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,6 @@ Once deployed, your Flask app will be accessible via the public IP exported by P
 ```bash
 pulumi stack output public_ip
 ```
-The value may be empty until the ECS task is running and a network interface has been created.
+This value may be empty until the ECS task is running and its network interface has been created.
 
 Visit `http://<public-ip>:5000` using the output value.

--- a/__main__.py
+++ b/__main__.py
@@ -112,12 +112,14 @@ service = ecs.Service("service",
 
 # Export the public IP of the first task's network interface
 def get_public_ip(sg_id: str):
+    """Return the public IP for the first ENI attached to the security group."""
     interfaces = aws.ec2.get_network_interfaces(
         filters=[{"name": "group-id", "values": [sg_id]}]
     )
     if not interfaces.ids:
         return None
-    return aws.ec2.get_network_interface(id=interfaces.ids[0]).association.public_ip
+    eni = aws.ec2.get_network_interface(id=interfaces.ids[0])
+    return eni.association.public_ip if eni.association else None
 
 public_ip = sg.id.apply(get_public_ip)
 pulumi.export("public_ip", public_ip)


### PR DESCRIPTION
## Summary
- return `None` when the security group has no ENI association
- expose the helper via `sg.id.apply(get_public_ip)`
- clarify README that the public IP output may be empty

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6842f590973c8321a9bf36ea6132ba71