### PR TITLE
Fix network interface public IP retrieval

### DIFF
--- a/__main__.py
+++ b/__main__.py
@@ -120,8 +120,9 @@ def get_public_ip(sg_id: str):
     def resolve_ip(ids):
         if not ids:
             return None
-        eni = aws.ec2.get_network_interface_output(id=ids[0])
-        return eni.apply(lambda i: i.association.public_ip if i.association else None)
+        # Using the blocking version of the data source avoids missing attributes
+        eni = aws.ec2.get_network_interface(id=ids[0])
+        return eni.association.public_ip if eni.association else None
 
     return interfaces.ids.apply(resolve_ip)
 


### PR DESCRIPTION
## Summary
- fix retrieval of the task network interface's public IP in `__main__.py`

## Testing
- `pytest -q` *(fails: 1 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_684300a9be1c832192aae8c092a5db10